### PR TITLE
Fix leaks check showing as failed incorrectly

### DIFF
--- a/tester.sh
+++ b/tester.sh
@@ -313,11 +313,12 @@ test_leaks() {
 			definitely_lost=$(cat tmp_valgrind-out.txt | grep "definitely lost:" | awk 'END{print $4}')
 			possibly_lost=$(cat tmp_valgrind-out.txt | grep "possibly lost:" | awk 'END{print $4}')
 			indirectly_lost=$(cat tmp_valgrind-out.txt | grep "indirectly lost:" | awk 'END{print $4}')
+			all_blocks_freed=$(cat tmp_valgrind-out.txt | grep "All heap blocks were freed -- no leaks are possible")
 			# echo "$definitely_lost"
 			# echo "$possibly_lost"
 			# echo "$indirectly_lost"
 			# Check if any bytes were lost
-			if [ "$definitely_lost" != "0" ] || [ "$possibly_lost" != "0" ] || [ "$indirectly_lost" != "0" ];
+			if [ "$definitely_lost" != "0" ] || [ "$possibly_lost" != "0" ] || [ "$indirectly_lost" != "0" ] && [[ -z "$all_blocks_freed" ]];
 			then
 				echo -ne "❌ "
 				((LEAKS++))


### PR DESCRIPTION
If there are no leaks, the other lines will be
missing and the script will interpret that as
a leak.