### PR TITLE
fix filenames for single tests in tester.sh

### DIFF
--- a/tester.sh
+++ b/tester.sh
@@ -38,22 +38,22 @@ main() {
 				TESTFILES+=" ${RUNDIR}/cmds/mand/1_redirs.sh"
 				;;
 			"pipelines" | "pi")
-				TESTFILES+=" ${RUNDIR}/cmds/mand/1_pipeline.sh"
+				TESTFILES+=" ${RUNDIR}/cmds/mand/1_pipelines.sh"
 				;;
 			"cmds" | "c")
-				TESTFILES+=" ${RUNDIR}/cmds/mand/1_scmd.sh"
+				TESTFILES+=" ${RUNDIR}/cmds/mand/1_scmds.sh"
 				;;
 			"variables" | "v")
 				TESTFILES+=" ${RUNDIR}/cmds/mand/1_variables.sh"
 				;;
 			"corrections" | "co")
-				TESTFILES+=" ${RUNDIR}/cmds/mand/1_corrections.sh"
+				TESTFILES+=" ${RUNDIR}/cmds/mand/2_correction.sh"
 				;;
 			"path")
-				TESTFILES+=" ${RUNDIR}/cmds/mand/1_path_check.sh"
+				TESTFILES+=" ${RUNDIR}/cmds/mand/2_path_check.sh"
 				;;
 			"syntax" | "s")
-				TESTFILES+=" ${RUNDIR}/cmds/mand/1_syntax_errors.sh"
+				TESTFILES+=" ${RUNDIR}/cmds/mand/8_syntax_errors.sh"
 				;;
 		esac
 		shift


### PR DESCRIPTION
Hello hello, from 42 Wolfsburg :wave: 

**First of all: Thx a lot for putting together this amazing tester! Helped us a lot while finishing our minishell and ruling out all the nitty-gritties!!**

### Now, to this PR:

It's a very simple one, but crucial i think. There were some incorrect file-paths hard-coded in `tester.sh` for the single test options like `mstest m c`. I guess this happened somewhere along the way while editing test-files. Anyhow, this lead to `mstest m c` not functioning any more because the corresponding test-file could not be found. I simply corrected the file-paths in `tester.sh` to match the real existing paths.  
